### PR TITLE
Filter games & save additional metadata

### DIFF
--- a/cycle2/analysis/wrangle.R
+++ b/cycle2/analysis/wrangle.R
@@ -238,6 +238,7 @@ if('cookies.txt' %in% list.files(paste(dd, sep = '/'))) {
                                                'consumableKey', 
                                                'settingsNum')],
                          by.x = "matchid", by.y = "matchID", all.x = TRUE)
+    gamesData <- subset(gamesData, consumableKey != "boomtown_demo")
     write.csv(gamesData, file = paste(od, 'gamesData.csv', sep = '/'),
               row.names = FALSE)
 } else {

--- a/cycle2/analysis/wrangle.R
+++ b/cycle2/analysis/wrangle.R
@@ -63,13 +63,24 @@ datalist <- lapply(files[!(files %in% 'cookies.txt')], function(x) {
     readLines(paste(dd, x, sep = '/'))
 })
                   
-# Select games that had at least one choice (had at least one "LeaderSelection") event
-# Select games played during fielding period (StartMatch date >= 10/25/2018)
-leaderSelection <- lapply(datalist, function(x) x[grep("LeaderSelection", x)])
+# LeaderSelection events before game suspended
+leaderSelectionAll <- lapply(datalist, function(x) x[grep("LeaderSelection|GameSuspended", x)])
+leaderSelection <- lapply(leaderSelectionAll, 
+                          function(x) if ('TRUE' %in% grepl("GameSuspended", x)) {
+                            x[0:(grep("GameSuspended", x)-1)]
+                          } else {
+                            x
+                          })
 leaderSelectionYes <- lapply(leaderSelection, function(x) length(as.character(x))>0 & length(as.character(x))<14)
+
+# Identify games played during fielding period (StartMatch date >= 10/25/2018)
 StartMatch <- lapply(datalist, function(x) gsub(" .*$", "", x[grep("StartMatch", x)]))
 dates <- lapply(StartMatch, function(x) as.Date((gsub("StartMatch,", "", x)), "%m/%d/%Y"))
 datesFIELD <- lapply(dates, function(x) x >= as.Date('2018-10-25'))
+
+# Subset datalist according to the two conditions above:
+# 1. Had at least one "LeaderSelection") event before the game was suspended
+# 2. Played during fielding period (StartMatch date >= 10/25/2018)
 datalist<-datalist[leaderSelectionYes==TRUE & datesFIELD==TRUE]
 
 # Count number of games

--- a/cycle2/analysis/wrangle.R
+++ b/cycle2/analysis/wrangle.R
@@ -8,7 +8,7 @@ URL <- 'https://volunteerscience.com/gallup/boomtown_metadata'
 # define constants
 gamedata_names <- c("matchid", "round", "h1.1", "h1.3", "h2.1", "h2.2", "h2.3",
                     "h2.4", "h2.5", "h2.6", "h3.2", "h3.3", "h3.4", "h3.5",
-                    "tools", "innovation", "CSE", "leaderChoice")
+                    "tools", "innovation", "CSE", "leaderChoice", "nConnected")
 str1.1 <- c("None", "Weak", "Normal", "Strong")
 str2.1 <- c("False", "True")
 str3.2 <- c("LowTolerance", "HighTolerance")
@@ -90,6 +90,12 @@ matchid <- mapply(function(x, n) {
     rep(x, n)
 }, matchid, nRounds, SIMPLIFY = FALSE)
 
+# Count number of connected players
+PlayerConnection <- lapply(datalist, function(x) length(x[grep("PlayerConnection", x)]))
+PlayerConnections <- mapply(function(nConnected, n) {
+  return(rep(nConnected, n))
+}, PlayerConnection, nRounds, SIMPLIFY = FALSE)              
+                  
 # Extract values for block-randomized hypotheses
 gameSettings <- lapply(datalist, function(x) x[grep("SetupMatch", x)])
 
@@ -191,7 +197,8 @@ gamesList <- list(
     tools,
     innovation,
     CSE,
-    leaderChoice
+    leaderChoice, 
+    PlayerConnections
 )
 
 # run a check on gamesList to ensure the flattening to a matrix/data frame


### PR DESCRIPTION
This PR updates the wrangle.R script to incorporate incomplete games and metadata. 

1. Filter games to exclude pilots and games that did not have any "leaderSelection" event.
2. Adjust number of rounds to reflect number of "leaderSelection" events.
3. Adjust "toolChoices" to align with number of "leaderSelection" events (sometimes there is a tool choice, but game ended before a leader selection happenned). 
4. Adjust length of h1.3 and h3.5 vectors to number of rounds played.
5. Save additional variables from the metadata for later analysis.